### PR TITLE
corrected the env var name

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Example add-on configuration:
       "value": "Hassio"
     },
     {
-      "name": "GF_ALLOW_SIGN_UP",
+      "name": "GF_USERS_ALLOW_SIGN_UP",
       "value": "true"
     }
   ]


### PR DESCRIPTION
This closes #15 

Signed-off-by: Christoph Görn <goern@b4mad.net>

# Proposed Changes

rename env var to correctly configure grafana on startup.

## Related Issues

#15 
