### PR TITLE
Support custom grafana-cli commands

### DIFF
--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -75,6 +75,15 @@ Grafana setup. For a list of available plugins, see:
 
 **Note**: _Adding plugins will result in a longer start-up for the add-on._
 
+### Option: `custom_grafana_cli_cmds`
+
+Allows running of custom grafana-cli commands, for example to install an addon from a non-standard repo. You do not need to add `grafana-cli`, the string will be appended for you, e.g.
+
+```yaml
+custom_grafana_cli_cmds:
+  - '--pluginUrl "https://mycustomplugin.com/releases/download/1.0.0/myplugin.zip" plugins install my-grafana-plugin'
+```
+
 ### Option: `env_vars`
 
 This option allows you to tweak every aspect of Grafana by setting

--- a/grafana/config.json
+++ b/grafana/config.json
@@ -16,6 +16,7 @@
   "map": ["ssl"],
   "options": {
     "plugins": [],
+    "custom_grafana_cli_cmds": [],
     "env_vars": [],
     "ssl": true,
     "certfile": "fullchain.pem",
@@ -30,6 +31,7 @@
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "plugins": ["str"],
+    "custom_grafana_cli_cmds": ["str"],
     "certfile": "str",
     "keyfile": "str",
     "ssl": "bool",

--- a/grafana/rootfs/etc/cont-init.d/grafana.sh
+++ b/grafana/rootfs/etc/cont-init.d/grafana.sh
@@ -50,3 +50,11 @@ if bashio::config.has_value 'plugins'; then
             || bashio::exit.nok "Failed installing Grafana plugin: ${plugin}"
     done
 fi
+
+# Run custom grafana-cli commands
+if bashio::config.has_value 'custom_grafana_cli_cmds'; then
+    for cmd in $(bashio::config 'custom_grafana_cli_cmds'); do
+        grafana-cli $cmd \
+            || bashio::exit.nok "Failed running grafana-cli command: grafana-cli ${cmd}"
+    done
+fi


### PR DESCRIPTION
# Proposed Changes

I need to be able to install plugins from custom URLs. This PR adds support for running custom grafana-cli commands at init time.

# References

Fixes matt-FFFFFF/hassio-addon-repository#5

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/