### PR TITLE
Map port 3000 instead of 80 for Grafana's external ports

### DIFF
--- a/grafana/config.json
+++ b/grafana/config.json
@@ -19,10 +19,10 @@
     "keyfile": "privkey.pem"
   },
   "ports": {
-    "80/tcp": null
+    "3000/tcp": null
   },
   "ports_description": {
-    "80/tcp": "Not required for Ingress"
+    "3000/tcp": "Not required for Ingress"
   },
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",


### PR DESCRIPTION
# Proposed Changes

Grafana API requires port 3000 to work. When deployed via hassio, this container does not have 3000 NAT'ed from the host to it. This means we cannot import sources etc, we get a 502 bad gateway. Even when publishing a reverse proxy rule this does not work, however, the basic all will work from outside directly to the container IP. What needs to happen is port 3000 listening on the host so that calls can then be sent into the container to the grafana API, or they can be proxied properly then.

## Related Issues

