### PR TITLE
Prevent direct access with ingress

### DIFF
--- a/grafana/rootfs/etc/services.d/grafana/run
+++ b/grafana/rootfs/etc/services.d/grafana/run
@@ -7,6 +7,14 @@
 declare -a options
 declare name
 declare value
+declare port
+
+port=$(bashio::addon.port 80)
+if ! bashio::var.has_value "${port}"; then
+    # Disable direct HTTP access for ingress
+    export GF_SERVER_HTTP_ADDR=127.0.0.1
+    export GF_AUTH_BASIC_ENABLED=false
+fi
 
 # Wait for Memcached to become available
 bashio::net.wait_for 11211


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

When poking around in the addon I noticed a minor security issue. When in ingress mode the addon sets up NGinx to deny all access other then from `172.30.32.2`. However the container still exposes direct HTTP access to the Grafana application on port 3000. Since that doesn't go through NGinx anything able to see the container can hit that. And would know the password since its in the `grafana.ini` file and can't be changed in Ingress mode.

Here's a test I did just to confirm I could, the `/users` API is one which requires authentication:
<img width="813" alt="Screen Shot 2021-03-31 at 9 18 49 PM" src="https://user-images.githubusercontent.com/2037026/113231854-1a474880-926a-11eb-9b4e-b5dc9c4a8964.png">

The risk here is small. The port is not exposed on the host so it can only be hit from within the docker network itself by other addons and things. But there is actually a very easy fix. By setting [server.http_addr](https://grafana.com/docs/grafana/latest/administration/configuration/#http_addr) to `127.0.0.1` we make it so nginx is the only thing allowed to talk directly to grafana. After pulling this branch locally into the `addons` folder this is what I get from my test:
<img width="536" alt="Screen Shot 2021-03-31 at 10 19 57 PM" src="https://user-images.githubusercontent.com/2037026/113234469-4fa26500-926f-11eb-9b72-ca944c440633.png">

This PR does this using an environmental variable set during `run` only if ingress is in use so it should have no impact on non-ingress use cases. I also turned off [auth.basic](https://grafana.com/docs/grafana/latest/administration/configuration/#authbasic) in ingress mode for good measure since there is no need for it, only auth proxy is allowed.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
