### PR TITLE
Add /health as watchdog url

### DIFF
--- a/grafana/config.json
+++ b/grafana/config.json
@@ -11,7 +11,7 @@
   "panel_title": "Grafana",
   "arch": ["aarch64", "amd64", "armv7"],
   "map": ["ssl"],
-  "watchdog": "http://[HOST]:3000/api/health",
+  "watchdog": "http://[HOST]:1337/api/health",
   "options": {
     "plugins": [],
     "env_vars": [],

--- a/grafana/config.json
+++ b/grafana/config.json
@@ -11,6 +11,7 @@
   "panel_title": "Grafana",
   "arch": ["aarch64", "amd64", "armv7"],
   "map": ["ssl"],
+  "watchdog": "http://[HOST]:3000/api/health",
   "options": {
     "plugins": [],
     "env_vars": [],


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Grafana has a [/health API](https://grafana.com/docs/grafana/latest/http_api/other/#returns-health-information-about-grafana) which does not require authentication and basically just returns whether Grafana is happily running or not. Setting the watchdog URL to this makes it so watchdog calls it regularly and restarts the addon if it receives an unhealthy response. 

Since the internal port that grafana listens on [needs to stay open](https://github.com/hassio-addons/addon-grafana/pull/127#issuecomment-811690742) I figured we might as well use it for these health checks since watchdog will always be able to reach grafana here, regardless of other configuration.

I pulled this branch locally to test and it seems to be running without issue. I guess the one very small note to make is that if someone has set the environmental variable `GF_SERVER_HTTP_ADDR` in their config then watchdog won't like it since it will be denied access on port `3000`. That's actually how I confirmed it was working, I let addon run fine for about an hour then added this to the config and saw I got a warning from watchdog in my log:

```yaml
env_vars:
  - name: GF_SERVER_HTTP_ADDR
    value: 127.0.0.1
```

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
