### PR TITLE
Add access to Home Assistant configuration so SQLite DB can be used

### DIFF
--- a/grafana/config.json
+++ b/grafana/config.json
@@ -10,7 +10,7 @@
   "panel_icon": "mdi:chart-timeline",
   "panel_title": "Grafana",
   "arch": ["aarch64", "amd64", "armv7"],
-  "map": ["ssl"],
+  "map": ["config", "ssl"],
   "options": {
     "plugins": [],
     "env_vars": [],


### PR DESCRIPTION
# Proposed Changes

Adds READ access to the Home Assistant configuration folder. This allows for the SQLite DB of Home Assistant to be used with Grafana.

## Related Issues

closes #133 