### PR TITLE
Remove NGINX access log from Supervisor log ouput

### DIFF
--- a/grafana/rootfs/etc/nginx/nginx.conf
+++ b/grafana/rootfs/etc/nginx/nginx.conf
@@ -27,11 +27,7 @@ events {
 http {
     include /etc/nginx/includes/mime.types;
 
-    log_format homeassistant '[$time_local] $status '
-                             '$http_x_forwarded_for($remote_addr) '
-                             '$request ($http_user_agent)';
-
-    access_log              /proc/1/fd/1 homeassistant;
+    access_log              off;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

Remove NGINX access log from Supervisor log output, it is not really helpful at this point.