### PR TITLE
Fix by temporary disable Grafana Live for now

### DIFF
--- a/grafana/rootfs/etc/grafana/grafana.ini
+++ b/grafana/rootfs/etc/grafana/grafana.ini
@@ -316,3 +316,7 @@ global_api_key = -1
 
 # global limit on number of logged in users.
 global_session = -1
+
+#################################### Grafana Live ##########################
+[live]
+max_connections = 0


### PR DESCRIPTION
# Proposed Changes

Temporary disabled the new Grafana Live features, fixes #173

This can probably be solved using new features exposed in the upcoming Supervisor. Disabling the feature for now, provides the same experience as before, but without all the log errors.
