### PR TITLE
Update DOCS.md

### DIFF
--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -108,7 +108,7 @@ for Home Assistant.
 - HTTP > Access: Server (Default)
 - Auth: (leave them all disabled)
 - InfluxDB Details > Database: _Your Home Assistant InfluxDB database_,
-  e.g., `homeassistant`
+  e.g., `home_assistant`
 - InfluxDB Details > User: _Grafana InfluxDB username defined in step 1_
 - InfluxDB Details > Password: _Grafana InfluxDB user password defined_
   _in step 1_


### PR DESCRIPTION
I don't believe I did anything special when installing and creating InfluxDB using the plugin. I followed these instructions and they all worked perfectly except for the database name. I get that "e.g." means example, but (as far as I could tell) the default database is home_assistant. This proposed change is to make the docs more copy/pastable for non-custom configs.

Feel free to reject, but I figured I'd try.

# Proposed Changes

> (Describe the changes and rationale behind them)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
