### PR TITLE
🔨 Add libxshmfence1 v1.3-1 for Image Renderer

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -47,6 +47,7 @@ RUN \
             libxi6=2:1.7.10-1 \
             libxrandr2=2:1.5.1-1 \
             libxrender1=1:0.9.10-1 \
+            libxshmfence1=1.3-1 \
             libxss1=1:1.2.3-1 \
             libxtst6=2:1.2.3-1 \
         && grafana-cli plugins install "grafana-image-renderer" "3.2.1"; \


### PR DESCRIPTION
# Proposed Changes

Add libxshmfence1 which appears to be missing from the dependencies for headless Chrome.

```
root@a0d7b954-grafana:/var/lib/grafana/plugins/grafana-image-renderer/chrome-linux# ldd chrome | grep not
        libxshmfence.so.1 => not found
```
I can't duplicate the logged issue (I am guessing it depends on the type of render??), however it should hopefully resolve.

## Related Issues

fixes #211 