### PR TITLE
Upgrade to Grafana 8.3.3

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 RUN \
-    GRAFANA="8.2.5" \
+    GRAFANA="8.3.1" \
     \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 RUN \
-    GRAFANA="8.3.1" \
+    GRAFANA="8.3.3" \
     \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \


### PR DESCRIPTION
https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/

# Proposed Changes

> [Security update which fixes Path Traversal](https://grafana.com/blog/2021/12/07/grafana-8.3.1-8.2.7-8.1.8-and-8.0.7-released-with-high-severity-security-fix/)

> https://github.com/grafana/grafana/releases/tag/v8.3.0