### PR TITLE
Allow non-admins to use Grafana

### DIFF
--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -10,6 +10,7 @@ ingress_port: 1337
 ingress_stream: true
 panel_icon: mdi:chart-timeline
 panel_title: Grafana
+panel_admin: false
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
# Proposed Changes

Set `panel_admin: false` to also allow non-administrators to use the addon.

It is this change https://github.com/hassio-addons/addon-grocy/pull/256 but for Grafana :)

## Related Issues

> https://github.com/hassio-addons/addon-grafana/issues/100, https://github.com/home-assistant/frontend/issues/5907

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
