### PR TITLE
Enables Grafana unified alerting and disables legacy dashboard alerting

### DIFF
--- a/grafana/rootfs/etc/grafana/grafana.ini
+++ b/grafana/rootfs/etc/grafana/grafana.ini
@@ -320,3 +320,10 @@ global_session = -1
 #################################### Grafana Live ##########################
 [live]
 max_connections = 0
+
+#################################### Alerting ##########################
+[unified_alerting]
+enabled = true
+
+[alerting]
+enabled = false


### PR DESCRIPTION
# Proposed Changes

This PR enables Grafana unified alerting and disables legacy dashboard alerting as documented in https://grafana.com/docs/grafana/latest/alerting/unified-alerting/opt-in/

Grafana Unified Alerting introduced since v8 is much more powerful than legacy dashboard alerting: https://grafana.com/docs/grafana/latest/alerting/unified-alerting/difference-old-new/

Existing legacy alert rules are migrated during startup.

## Related Issues

N/A