### PR TITLE
⬆️ Upgrades Grafana Image Renderer to 3.4.1

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -50,7 +50,7 @@ RUN \
             libxshmfence1=1.3-1 \
             libxss1=1:1.2.3-1 \
             libxtst6=2:1.2.3-1 \
-        && grafana-cli plugins install "grafana-image-renderer" "3.3.0"; \
+        && grafana-cli plugins install "grafana-image-renderer" "3.4.1"; \
     fi \
     \
     && rm -fr \


### PR DESCRIPTION
# Proposed Changes

- https://github.com/grafana/grafana-image-renderer/releases/tag/v3.4.0
- https://github.com/grafana/grafana-image-renderer/releases/tag/v3.4.1

Replaces and closes #248