### PR TITLE
Upgrade Grafana to v9.3.6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/workflows/.github/workflows/addon-ci.yaml@main
+    uses: addon-grafana/.github/workflows/addon-ci.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   workflows:
-    uses: .github/workflows/addon-ci.yaml@main
+    uses: ./.github/workflows/addon-ci.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/.github/workflows/addon-ci.yaml@main
+    uses: .github/workflows/addon-ci.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/addon-ci.yaml@main
+    uses: addon-grafana/workflows/.github/workflows/addon-ci.yaml@main

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,6 +15,6 @@ on:
 jobs:
   workflows:
     uses: hassio-addons/workflows/.github/workflows/addon-deploy.yaml@main
-    secrets:
-      CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
-      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+   # secrets:
+   #   CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
+   #   DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,6 +15,6 @@ on:
 jobs:
   workflows:
     uses: hassio-addons/workflows/.github/workflows/addon-deploy.yaml@main
-    secrets:
-      CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
-      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+    # secrets:
+      # CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
+      # DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/workflows/.github/workflows/addon-deploy.yaml@main
+    uses: addon-grafana/.github/workflows/addon-deploy.yaml@main
     # secrets:
       # CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
       # DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/addon-deploy.yaml@main
+    uses: addon-grafana/workflows/.github/workflows/addon-deploy.yaml@main
     # secrets:
       # CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
       # DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,6 +15,6 @@ on:
 jobs:
   workflows:
     uses: hassio-addons/workflows/.github/workflows/addon-deploy.yaml@main
-   # secrets:
-   #   CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
-   #   DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+    secrets:
+      CAS_API_KEY: ${{ secrets.CAS_API_KEY }}
+      DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/workflows/.github/workflows/labels.yaml@main
+    uses: addon-grafana/.github/workflows/labels.yaml@main

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/labels.yaml@main
+    uses: addon-grafana/workflows/.github/workflows/labels.yaml@main

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/lock.yaml@main
+    uses: addon-grafana/workflows/.github/workflows/lock.yaml@main

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/workflows/.github/workflows/lock.yaml@main
+    uses: addon-grafana/.github/workflows/lock.yaml@main

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/pr-labels.yaml@main
+    uses: addon-grafana/workflows/.github/workflows/pr-labels.yaml@main

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/workflows/.github/workflows/pr-labels.yaml@main
+    uses: addon-grafana/.github/workflows/pr-labels.yaml@main

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/workflows/.github/workflows/release-drafter.yaml@main
+    uses: addon-grafana/.github/workflows/release-drafter.yaml@main

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/release-drafter.yaml@main
+    uses: addon-grafana/workflows/.github/workflows/release-drafter.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: hassio-addons/workflows/.github/workflows/stale.yaml@main
+    uses: addon-grafana/workflows/.github/workflows/stale.yaml@main

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   workflows:
-    uses: addon-grafana/workflows/.github/workflows/stale.yaml@main
+    uses: addon-grafana/.github/workflows/stale.yaml@main

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 RUN \
-    GRAFANA="9.2.4" \
+    GRAFANA="9.3.6" \
     \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,7 +8,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 RUN \
-    GRAFANA="9.3.6" \
+    GRAFANA="9.4.3" \
     \
     && ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \


### PR DESCRIPTION
# Proposed Changes

Grafana Labs released a security fix for several critical and moderate issues.
https://grafana.com/blog/2023/01/25/grafana-security-releases-new-versions-with-fixes-for-cve-2022-23552-cve-2022-41912-and-cve-2022-39324/?pg=graf&plcmt=top-promo-banner

Expected behavior
Critical security issue is fixed and new features for Grafana:
https://grafana.com/docs/grafana/next/whatsnew/whats-new-in-v9-3/

## Related Issues

> [298]

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
