### PR TITLE
Allow installation of unsigned plugins using an URL

### DIFF
--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -40,8 +40,8 @@ Example add-on configuration:
 log_level: info
 grafana_ingress_user: frenck
 plugins:
-  - name: ayoungprogrammer-finance-datasource
-  - name: grafana-clock-panel
+  - ayoungprogrammer-finance-datasource
+  - grafana-clock-panel
 env_vars:
   - name: GF_DEFAULT_INSTANCE_NAME
     value: Hassio
@@ -79,26 +79,23 @@ Grafana setup. For a list of available plugins, see:
 
 <https://grafana.com/plugins>
 
-If you want to install a plugin from an URL, add the key `url` to the plugin
-configuration:
+**Note**: _Adding plugins will result in a longer start-up for the add-on._
 
-```yaml
-plugins:
-  - name: my-plugin-name
-    url: https://github.com/my-repo/my-plugin-name/releases/download/0.1.0/my-plugin-name-0.1.0.zip
-```
+### Option: `custom_plugins`
+
+Allows you to specify additional Grafana custom plugins to be installed to your
+Grafana setup from an URL.
+You must speficy the property `url` to the plugin configuration.
 
 Starting with Grafana 7.x, it is mandatory to have plugins signed when running in production mode.
-If you want to install unsigned plugins, you must set the `unsigned` property to `true`:
+If you want to install unsigned plugins, you must also set the `unsigned` property to `true`:
 
 ```yaml
-plugins:
-  - name: my-unsigned-plugin-name
-    url: https://github.com/my-other-repo/my-unsigned-plugin-name/releases/download/0.1.0/my-unsigned-plugin-name-0.1.0.zip
+custom_plugins:
+  - name: my-plugin-name
+    url: https://github.com/my-repo/my-plugin-name/releases/download/0.1.0/my-plugin-name-0.1.0.zip
     unsigned: true
 ```
-
-**Note**: _Adding plugins will result in a longer start-up for the add-on._
 
 ### Option: `env_vars`
 

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -85,7 +85,7 @@ Grafana setup. For a list of available plugins, see:
 
 Allows you to specify additional Grafana custom plugins to be installed to your
 Grafana setup from an URL.
-You must speficy the property `url` to the plugin configuration.
+You must specify the property `url` to the plugin configuration.
 
 Starting with Grafana 7.x, it is mandatory to have plugins signed when running in production mode.
 If you want to install unsigned plugins, you must also set the `unsigned` property to `true`:

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -88,6 +88,16 @@ plugins:
     url: https://github.com/my-repo/my-plugin-name/releases/download/0.1.0/my-plugin-name-0.1.0.zip
 ```
 
+Starting with Grafana 7.x, it is mandatory to have plugins signed when running in production mode.
+If you want to install unsigned plugins, you must set the `unsigned` property to `true`:
+
+```yaml
+plugins:
+  - name: my-unsigned-plugin-name
+    url: https://github.com/my-other-repo/my-unsigned-plugin-name/releases/download/0.1.0/my-unsigned-plugin-name-0.1.0.zip
+    unsigned: true
+```
+
 **Note**: _Adding plugins will result in a longer start-up for the add-on._
 
 ### Option: `env_vars`
@@ -147,17 +157,6 @@ It is not possible to enable anonymous or non-administrator access with Home
 Assistant Cloud. This includes embedding Grafana resources with an iframe or
 rendered image inside of a dashboard. For more details see
 [Anonymous login not working, Grafana add-on 3.0.0 #55](https://github.com/hassio-addons/addon-grafana/issues/55).
-
-## Unsigned plugins
-
-Starting with Grafana 7.x, it is mandatory to have plugins signed when running in production mode.
-However, there is an option to allow loading unsigned plugins:
-
-```yaml
-env_vars:
-  - name: GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
-    value: my-plugin-name
-```
 
 ## Known issues and limitations
 

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -40,8 +40,8 @@ Example add-on configuration:
 log_level: info
 grafana_ingress_user: frenck
 plugins:
-  - ayoungprogrammer-finance-datasource
-  - grafana-clock-panel
+  - name: ayoungprogrammer-finance-datasource
+  - name: grafana-clock-panel
 env_vars:
   - name: GF_DEFAULT_INSTANCE_NAME
     value: Hassio
@@ -78,6 +78,15 @@ Allows you to specify additional Grafana plugins to be installed to your
 Grafana setup. For a list of available plugins, see:
 
 <https://grafana.com/plugins>
+
+If you want to install a plugin from an URL, add the key `url` to the plugin
+configuration:
+
+```yaml
+plugins:
+  - name: my-plugin-name
+    url: https://github.com/my-repo/my-plugin-name/releases/download/0.1.0/my-plugin-name-0.1.0.zip
+```
 
 **Note**: _Adding plugins will result in a longer start-up for the add-on._
 
@@ -138,6 +147,17 @@ It is not possible to enable anonymous or non-administrator access with Home
 Assistant Cloud. This includes embedding Grafana resources with an iframe or
 rendered image inside of a dashboard. For more details see
 [Anonymous login not working, Grafana add-on 3.0.0 #55](https://github.com/hassio-addons/addon-grafana/issues/55).
+
+## Unsigned plugins
+
+Starting with Grafana 7.x, it is mandatory to have plugins signed when running in production mode.
+However, there is an option to allow loading unsigned plugins:
+
+```yaml
+env_vars:
+  - name: GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS
+    value: my-plugin-name
+```
 
 ## Known issues and limitations
 

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -87,7 +87,6 @@ Allows you to specify additional Grafana custom plugins to be installed to your
 Grafana setup from an URL.
 You must specify the property `url` to the plugin configuration.
 
-Starting with Grafana 7.x, it is mandatory to have plugins signed when running in production mode.
 If you want to install unsigned plugins, you must also set the `unsigned` property to `true`:
 
 ```yaml

--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -32,7 +32,8 @@ ports_description:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   plugins:
-    - str
+    - name: str
+      url: str?
   certfile: str
   keyfile: str
   ssl: bool

--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -21,6 +21,7 @@ map:
   - ssl
 options:
   plugins: []
+  custom_plugins: []
   env_vars: []
   ssl: true
   certfile: fullchain.pem
@@ -32,8 +33,11 @@ ports_description:
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   plugins:
+    - str
+  custom_plugins:
     - name: str
-      url: str?
+      url: str
+      unsigned: bool?
   certfile: str
   keyfile: str
   ssl: bool

--- a/grafana/rootfs/etc/grafana/grafana.ini
+++ b/grafana/rootfs/etc/grafana/grafana.ini
@@ -22,6 +22,10 @@ logs = /var/logs/grafana
 #
 plugins = /var/lib/grafana/plugins
 
+#################################### Plugins ####################################
+[plugins]
+allow_loading_unsigned_plugins = 
+
 #################################### Server ####################################
 [server]
 # Protocol (http or https)

--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/grafana/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/grafana/run
@@ -5,6 +5,7 @@
 # Runs the Grafana Server
 # ==============================================================================
 declare -a options
+declare -a unsigned_plugins
 declare name
 declare value
 
@@ -23,6 +24,18 @@ for var in $(bashio::config 'env_vars|keys'); do
     bashio::log.info "Setting ${name} to ${value}"
     export "${name}=${value}"
 done
+
+# Verify if we have unsigned plugins to load
+if bashio::config.has_value 'plugins'; then
+    for plugin in $(bashio::config 'plugins|keys'); do
+        name=$(bashio::config "plugins[${plugin}].name")
+        if bashio::config.true "plugins[${plugin}].unsigned"; then
+            unsigned_plugins+="${name},"
+		fi
+    done
+	export "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=${unsigned_plugins}"
+fi
+
 
 # Run Grafana
 exec grafana-server "${options[@]}"

--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/grafana/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/grafana/run
@@ -25,15 +25,15 @@ for var in $(bashio::config 'env_vars|keys'); do
     export "${name}=${value}"
 done
 
-# Verify if we have unsigned plugins to load
-if bashio::config.has_value 'plugins'; then
-    for plugin in $(bashio::config 'plugins|keys'); do
-        name=$(bashio::config "plugins[${plugin}].name")
-        if bashio::config.true "plugins[${plugin}].unsigned"; then
+# Verify if we have unsigned custom plugins to load
+if bashio::config.has_value 'custom_plugins'; then
+    for plugin in $(bashio::config 'custom_plugins|keys'); do
+        name=$(bashio::config "custom_plugins[${plugin}].name")
+        if bashio::config.true "custom_plugins[${plugin}].unsigned"; then
             unsigned_plugins+="${name},"
-		fi
+        fi
     done
-	export "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=${unsigned_plugins}"
+    export "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=${unsigned_plugins}"
 fi
 
 

--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
@@ -46,17 +46,19 @@ sed -i "s#%%ingress_entry%%#${ingress_entry}#g" "${CONFIG}"
 
 # Install user configured/requested Grafana plugins
 if bashio::config.has_value 'plugins'; then
-    for plugin in $(bashio::config 'plugins|keys'); do
-        name=$(bashio::config "plugins[${plugin}].name")
-        if bashio::config.exists "plugins[${plugin}].url"; then
-            url=$(bashio::config "plugins[${plugin}].url")
-            bashio::log.debug "Installing ${name} from ${url}"
-            grafana-cli --pluginUrl ${url} plugins install "$name" \
-                || bashio::exit.nok "Failed installing Grafana plugin: ${name} from: ${url}"
-        else
-            bashio::log.debug "Installing ${name}"
-            grafana-cli plugins install "$name" \
-                || bashio::exit.nok "Failed installing Grafana plugin: ${name}"
-		fi
+    for plugin in $(bashio::config 'plugins'); do
+        grafana-cli plugins install "$plugin" \
+            || bashio::exit.nok "Failed installing Grafana plugin: ${plugin}"
+    done
+fi
+
+# Install user configured/requested Grafana custom plugins (from URL)
+if bashio::config.has_value 'custom_plugins'; then
+    for plugin in $(bashio::config 'custom_plugins|keys'); do
+        name=$(bashio::config "custom_plugins[${plugin}].name")
+        url=$(bashio::config "custom_plugins[${plugin}].url")
+        bashio::log.debug "Installing custom plugin ${name} from ${url}"
+        grafana-cli --pluginUrl ${url} plugins install $name \
+            || bashio::exit.nok "Failed installing Grafana custom plugin: ${name} from: ${url}"
     done
 fi

--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
@@ -46,8 +46,17 @@ sed -i "s#%%ingress_entry%%#${ingress_entry}#g" "${CONFIG}"
 
 # Install user configured/requested Grafana plugins
 if bashio::config.has_value 'plugins'; then
-    for plugin in $(bashio::config 'plugins'); do
-        grafana-cli plugins install "$plugin" \
-            || bashio::exit.nok "Failed installing Grafana plugin: ${plugin}"
+    for plugin in $(bashio::config 'plugins|keys'); do
+        name=$(bashio::config "plugins[${plugin}].name")
+        if bashio::config.exists "plugins[${plugin}].url"; then
+            url=$(bashio::config "plugins[${plugin}].url")
+            bashio::log.debug "Installing ${name} from ${url}"
+            grafana-cli --pluginUrl ${url} plugins install "$name" \
+                || bashio::exit.nok "Failed installing Grafana plugin: ${name} from: ${url}"
+        else
+            bashio::log.debug "Installing ${name}"
+            grafana-cli plugins install "$name" \
+                || bashio::exit.nok "Failed installing Grafana plugin: ${name}"
+		fi
     done
 fi


### PR DESCRIPTION
# Proposed Changes

Allow the installation of Grafana plugins directly from an URL and also add an option to allow running plugins which are not signed.
This is a breaking change as plugin list now must have the key ```name``` on it to allow the URL key part of it.

## Related Issues

None

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
