### PR TITLE
🔨 Change health check direct to Grafana

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -67,7 +67,7 @@ COPY rootfs /
 
 # Health check
 HEALTHCHECK \
-    CMD curl --fail http://127.0.0.1:1337/api/health || exit 1
+    CMD curl --fail http://127.0.0.1:3000/api/health || exit 1
 
 # Build arguments
 ARG BUILD_ARCH


### PR DESCRIPTION
# Proposed Changes

Change Docker health check directly to the Grafana endpoint, unfortunately this means we cannot validate nginx itself, but as nginx isn't bound to localhost, it will fail to respond.  I assume the previous watchdog command was run by the supervisor, which is why it would succeed.

## Related Issues

Fixes #337 


