### PR TITLE
Remove nginx ingress server listening on a single interface

### DIFF
--- a/grafana/rootfs/etc/nginx/servers/ingress.conf
+++ b/grafana/rootfs/etc/nginx/servers/ingress.conf
@@ -1,5 +1,5 @@
 server {
-    listen %%interface%%:1337 default_server;
+    listen 1337 default_server;
 
     include /etc/nginx/includes/server_params.conf;
     include /etc/nginx/includes/proxy_params.conf;

--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -31,9 +31,6 @@ if bashio::var.has_value "${port}"; then
     sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/nginx/servers/direct.conf
 fi
 
-ingress_interface=$(bashio::addon.ip_address)
-sed -i "s/%%interface%%/${ingress_interface}/g" /etc/nginx/servers/ingress.conf
-
 grafana_user='admin'
 if bashio::config.has_value 'grafana_ingress_user'; then
     grafana_user=$(bashio::config 'grafana_ingress_user')


### PR DESCRIPTION
# Proposed Changes

Not sure why, but the add-on listens on a single network interface; while the add-on is not running in host network mode either.

It can just listen to all interfaces (including localhost).

../Frenck
