### PR TITLE
Do not install Grafana Image Renderer plugin by default

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,14 +32,6 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "grafana/grafana"
-    },
-    {
-      "fileMatch": ["/Dockerfile$"],
-      "matchStrings": [
-        "ARG GRAFANA_IMAGE_RENDERER_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "grafana/grafana-image-renderer"
     }
   ],
   "packageRules": [

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -40,6 +40,7 @@ Example add-on configuration:
 log_level: info
 grafana_ingress_user: frenck
 plugins:
+  - grafana-image-renderer
   - ayoungprogrammer-finance-datasource
   - grafana-clock-panel
 env_vars:

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,7 +8,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 ARG GRAFANA_VERSION="v10.3.1"
-ARG GRAFANA_IMAGE_RENDERER_VERSION="v3.9.1"
 RUN \
     ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
@@ -51,7 +50,6 @@ RUN \
             libxshmfence1=1.3-1 \
             libxss1=1:1.2.3-1 \
             libxtst6=2:1.2.3-1.1 \
-        && grafana-cli plugins install "grafana-image-renderer" "${GRAFANA_IMAGE_RENDERER_VERSION#v}"; \
     fi \
     \
     && rm -fr \


### PR DESCRIPTION
# Proposed Changes

Do not install Grafana Renderer Plugin by default on amd64 architectures. 
Any user who wants to use this plugin can add it to the list of plugins as described [in the documentation](https://github.com/hassio-addons/addon-grafana/blob/main/grafana/DOCS.md#option-plugins) like they would with any other desired plugin.

This is currently the only plugin installed by default, and as a user not looking at the source code it is not obvious why this plugin is installed and running. Additionally I can't remove the plugin since it will be reinstalled after every addon-reboot.

Also this plugin uses up CPU even when not in use (see #380).

## Related Issues

#380
