### PR TITLE
Add access to share for use with other add-ons

### DIFF
--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -18,6 +18,8 @@ arch:
   - armv7
 map:
   - homeassistant_config
+  - media
+  - share
   - ssl
 options:
   plugins: []

--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -18,7 +18,6 @@ arch:
   - armv7
 map:
   - homeassistant_config
-  - media
   - share
   - ssl
 options:


### PR DESCRIPTION
# Proposed Changes

Add acces to the directories `/media` and `/share`, as originally requested in #133. According to [this post](https://community.home-assistant.io/t/ha-addon-devs-what-folder-should-be-used-to-transfer-files-to-ha-core/641617/2?u=bemer) in the community forum, these folders are intended for the sharing of files between (home assistant and) addons, so I think the addon should have access to them.

> All 3 of /media, /ssl and /share were designed in part to be a place shared between Home Assistant and Addons so multiple things could read and write to it and potentially communicate with each other. /share was kind of the bucket for files which didn’t fit the obvious types of the other two (media in /media, ssl-related files in /ssl, everything else in /share).

The specific use case that brought me to this: I have an SQLite database file that I want to store locally and read in Grafana. I could put it in `/homeassistant_config` or `/ssl`, but conceptually it doesn't fit there. I'd much prefer having it in `/share`.

## Related Issues

Originally discussed in #133.
