### PR TITLE
Change default cert/key path and alllow the use of a different fullpath for cert/key

### DIFF
--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -25,8 +25,8 @@ options:
   custom_plugins: []
   env_vars: []
   ssl: true
-  certfile: fullchain.pem
-  keyfile: privkey.pem
+  certfile: /ssl/fullchain.pem
+  keyfile: /ssl/privkey.pem
 ports:
   80/tcp: null
 ports_description:

--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -25,8 +25,9 @@ options:
   custom_plugins: []
   env_vars: []
   ssl: true
-  certfile: /ssl/fullchain.pem
-  keyfile: /ssl/privkey.pem
+  sslpath: /ssl/
+  certfile: fullchain.pem
+  keyfile: privkey.pem
 ports:
   80/tcp: null
 ports_description:
@@ -39,6 +40,7 @@ schema:
     - name: str
       url: str
       unsigned: bool?
+  sslpath: str
   certfile: str
   keyfile: str
   ssl: bool

--- a/grafana/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/grafana/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -5,8 +5,8 @@ server {
     include /etc/nginx/includes/ssl_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
 
-    ssl_certificate /ssl/%%certfile%%;
-    ssl_certificate_key /ssl/%%keyfile%%;
+    ssl_certificate %%certfile%%;
+    ssl_certificate_key %%keyfile%%;
 
     location / {
         return 302 $scheme://$http_host%%ingress_entry%%/;

--- a/grafana/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/grafana/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -5,8 +5,8 @@ server {
     include /etc/nginx/includes/ssl_params.conf;
     include /etc/nginx/includes/proxy_params.conf;
 
-    ssl_certificate %%certfile%%;
-    ssl_certificate_key %%keyfile%%;
+    ssl_certificate %%sslpath%%/%%certfile%%;
+    ssl_certificate_key %%sslpath%%/%%keyfile%%;
 
     location / {
         return 302 $scheme://$http_host%%ingress_entry%%/;


### PR DESCRIPTION
# Proposed Changes

This would change the default config for fullchain.pem and privkey.pem to add the fullpath /ssl/*.pem as default location and remove the hardcoded path of /ssl/ in the nginx config to allow the use of fullpath Ex. /share/my_ssl_cert_nfs_mount/fullchain.pem.

This should be verified with existing configuration before merging as I was not able to confirm this will not cause regression for people already having a working configuration using the old defaults. 

## Related Issues
fixes #401  

