### PR TITLE
🔨 Remove auth header for direct access

### DIFF
--- a/grafana/rootfs/etc/nginx/servers/direct-ssl.disabled
+++ b/grafana/rootfs/etc/nginx/servers/direct-ssl.disabled
@@ -13,6 +13,7 @@ server {
     }
     location %%ingress_entry%% {
         rewrite  ^%%ingress_entry%%/(.*)  /$1 break;
+        proxy_set_header X-WEBAUTH-USER "";
         proxy_pass http://backend/;
     }
 

--- a/grafana/rootfs/etc/nginx/servers/direct.disabled
+++ b/grafana/rootfs/etc/nginx/servers/direct.disabled
@@ -9,6 +9,7 @@ server {
     }
     location %%ingress_entry%% {
         rewrite  ^%%ingress_entry%%/(.*)  /$1 break;
+        proxy_set_header X-WEBAUTH-USER "";
         proxy_pass http://backend/;
     }
 }


### PR DESCRIPTION
# Proposed Changes

As we mimic LDAP auth for ease of ingress access, this means any user specified in the auth header will be dynamically created as a read only user.  As this functionality isn't required for direct access, probably best to force remove it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured the X-WEBAUTH-USER header is explicitly set to an empty value for certain proxied requests, improving header consistency in specific Nginx server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->