### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -104,8 +101,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-grafana.svg
 [commits]: https://github.com/hassio-addons/addon-grafana/commits/main
 [contributors]: https://github.com/hassio-addons/addon-grafana/graphs/contributors
@@ -120,7 +115,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-grafana/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-grafana/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-grafana.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -156,8 +156,6 @@ rendered image inside of a dashboard. For more details see
 
 ## Known issues and limitations
 
-- This add-on does support ARM-based devices, nevertheless, they must
-  at least be an ARMv7 device. (Raspberry Pi 1 and Zero is not supported).
 - `To render a panel image, you must install the Grafana Image Renderer plugin.`
   This message is shown on ARM devices, like a Raspberry Pi. The Grafana Image
   Renderer plugin is not available for these devices.

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -12,7 +12,6 @@ ARG GRAFANA_IMAGE_RENDERER_VERSION="v4.1.5"
 RUN \
     ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
-    && if [ "${BUILD_ARCH}" = "armv7" ]; then ARCH="armhf"; fi \
     \
     && curl -J -L -o /tmp/grafana.deb \
         "https://dl.grafana.com/oss/release/grafana_${GRAFANA_VERSION#v}_${ARCH}.deb" \

--- a/grafana/build.yaml
+++ b/grafana/build.yaml
@@ -2,4 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/debian-base/aarch64:8.1.4
   amd64: ghcr.io/hassio-addons/debian-base/amd64:8.1.4
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:8.1.4

--- a/grafana/config.yaml
+++ b/grafana/config.yaml
@@ -14,7 +14,6 @@ panel_title: Grafana
 arch:
   - aarch64
   - amd64
-  - armv7
 map:
   - homeassistant_config
   - share


### PR DESCRIPTION
# Proposed Changes

The Home Assistant project has deprecated the armv7 architecture; pending to be fully dropped in the Home Assistant 2025.12 release. This PR removes it from this add-on.

../Frenck  

<p>
  <a href="https://www.linkedin.com/in/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/linkedin.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://youtube.com/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/youtube.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://bsky.app/profile/frenck.social"><img src="https://github.com/frenck/frenck/raw/main/images/bluesky.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://fosstodon.org/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/mastodon.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.instagram.com/frenck/"><img src="https://github.com/frenck/frenck/raw/main/images/instagram.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.threads.net/@frenck"><img src="https://github.com/frenck/frenck/raw/main/images/threads.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.facebook.com/frenck.dev/"><img src="https://github.com/frenck/frenck/raw/main/images/facebook.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://x.com/frenck"><img src="https://github.com/frenck/frenck/raw/main/images/x.svg" width="18" height="18"></a>
  &nbsp;&nbsp;
  <a href="https://www.tiktok.com/@frenck.nl"><img src="https://github.com/frenck/frenck/raw/main/images/tiktok.svg" width="18" height="18"></a>
</p>

Blogging my personal ramblings at <a href="https://frenck.dev">frenck.dev</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for armv7, armhf, and i386 architectures. The project now supports aarch64 and amd64 platforms only. Build configurations and documentation updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->