### PR TITLE
⬆️ Update grafana/grafana to v13.2.0 (fix stale apt pins)

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -7,7 +7,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base system
 ARG BUILD_ARCH=amd64
-ARG GRAFANA_VERSION="v12.3.1"
+ARG GRAFANA_VERSION="v13.2.0"
 ARG GRAFANA_IMAGE_RENDERER_VERSION="v4.1.5"
 RUN \
     ARCH="${BUILD_ARCH}" \
@@ -21,21 +21,21 @@ RUN \
         fonts-noto-cjk=1:20240730+repack1-1 \
         libfontconfig1=2.15.0-2.3 \
         memcached=1.6.38-1 \
-        musl=1.2.5-3 \
-        nginx=1.26.3-3+deb13u1 \
+        musl=1.2.5-3.1~deb13u1 \
+        nginx=1.26.3-3+deb13u7 \
     \
     && dpkg --install /tmp/grafana.deb \
     \
     && if [ "${BUILD_ARCH}" = "amd64" ]; then \
         apt-get install -y --no-install-recommends \
             libasound2t64=1.2.14-1 \
-            libcups2t64=2.4.10-3+deb13u1 \
+            libcups2t64=2.4.10-3+deb13u2 \
             libdbus-1-3=1.16.2-2 \
             libdrm-amdgpu1=2.4.124-2 \
-            libgbm1=25.0.7-2 \
-            libglib2.0-0t64=2.84.4-3~deb13u1 \
+            libgbm1=25.0.7-2+deb13u1 \
+            libglib2.0-0t64=2.84.4-3~deb13u3 \
             libgtk-4-1=4.18.6+ds-2 \
-            libnss3=2:3.110-1 \
+            libnss3=2:3.110-1+deb13u3 \
             libx11-6=2:1.8.12-1 \
             libx11-xcb1=2:1.8.12-1 \
             libxcb-dri3-0=1.17.0-2+b1 \


### PR DESCRIPTION
# :arrow_up: Update grafana/grafana to v13.2.0

Bumps `grafana/grafana` from `v12.3.1` to `v13.2.0` and refreshes the Debian package pins so the image builds again.

## Why

Renovate's PR #502 (same version bump) is failing CI because the `apt-get install` step can't resolve several **exact-version pins** that have since been superseded in the Debian 13 (trixie) repositories:

```
E: Version '1.2.5-3' for 'musl' was not found
E: Version '1.26.3-3+deb13u1' for 'nginx' was not found
```

The CI log only surfaced `musl` and `nginx` (the build aborts at the first `apt-get install`); four more pins in the `amd64`-only block were also stale and would have failed next. The current `main` branch is affected by the same staleness, so nothing builds until these pins are refreshed.

The pins went stale silently because the Renovate `repology` datasource that's supposed to track them is currently unable to look up updates ("Some dependencies could not be looked up" in the Renovate PR body).

## Changes

Bump Grafana and refresh six apt package pins to the versions currently published in Debian 13 (trixie), verified against the live `trixie` Packages index for both `amd64` and `arm64`:

| Package | Was | Now |
|---|---|---|
| `grafana/grafana` | `v12.3.1` | `v13.2.0` |
| `musl` | `1.2.5-3` | `1.2.5-3.1~deb13u1` |
| `nginx` | `1.26.3-3+deb13u1` | `1.26.3-3+deb13u7` |
| `libcups2t64` | `2.4.10-3+deb13u1` | `2.4.10-3+deb13u2` |
| `libgbm1` | `25.0.7-2` | `25.0.7-2+deb13u1` |
| `libglib2.0-0t64` | `2.84.4-3~deb13u1` | `2.84.4-3~deb13u3` |
| `libnss3` | `2:3.110-1` | `2:3.110-1+deb13u3` |

## Verification

- Grafana `13.2.0` `.deb` artifacts confirmed downloadable for `amd64` and `arm64`.
- `grafana-image-renderer` `4.1.5` plugin still published (`status: active`, `linux-amd64` package present).
- All refreshed pins resolve against the current `trixie` archive (both architectures).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Grafana to version 13.2.0.
  * Updated bundled system and browser-related packages for compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->