### PR TITLE
Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,11 +22,11 @@
       "fileMatch": ["/Dockerfile$"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
+        "\\s\\s(?<package>[a-z0-9][a-z0-9.+-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{package}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     },
     {
       "customType": "regex",
@@ -49,7 +49,12 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Port of hassio-addons/app-vaultwarden#447 to this repository.

Repology has become unreliable as a datasource lately: throttling, timeouts, and missing packages. It also forces us to map binary package names onto source package names. Renovate ships a native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) that reads the Debian package indices directly, so this switches the apt pins over to it. It indexes **binary** package names, which means `depNameTemplate` becomes plain `{{{package}}}` and the name mapping problem disappears.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`, verified against the image:

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

The `deb` datasource uses a `merge` registry strategy, so releases from all three are aggregated rather than first one wins.

### Also fixed: one pin was never tracked at all

The package name capture group was `[a-z0-9][a-z0-9-]+`, which excludes `.`. That silently dropped `libglib2.0-0t64`: it matched nothing, so Renovate never proposed updates for it. Widening the class to `[a-z0-9][a-z0-9.+-]+` brings the matcher to 27 of 27 pins in the Dockerfile, with no false positives. This is independent of the datasource switch, but it is the same defect class, so it is fixed here rather than left behind.

### Known limitation

The datasource currently hardcodes `Packages.gz`, but `trixie-updates` and `trixie-security` serve only `Packages.xz`. Confirmed still true at the time of writing: `Packages.gz` returns 200 for `trixie` `main` and 404 for both of the others. Those two suites are therefore inert for now. This fails gracefully: lookups are caught and skipped per component, so `trixie` `main` keeps working, and the other two start working by themselves once renovatebot/renovate#44330 is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

The practical impact here is limited to `libnss3`, which is pinned at `2:3.110-1+deb13u4` from `trixie-security`; `main` does not carry that version. It will need a manual bump until the next point release folds it into `main`. `nginx` resolves from both `trixie` and `trixie-security`, and the remaining 25 pins all resolve from `main`, so they update as normal.

Validated with `renovate-config-validator` from Renovate 44.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Port of hassio-addons/app-vaultwarden#447.

Upstream: renovatebot/renovate#44330

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Debian package update detection.
  * Added support for additional Debian package-name formats.
  * Updated package sources to include Trixie, Trixie-updates, and Debian security repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->