### PR TITLE
Use the bashio app namespace instead of the deprecated addon aliases

### DIFF
--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
@@ -46,7 +46,7 @@ fi
 secret=$(</data/secret)
 sed -i "s/secret_key.*/secret_key = ${secret}/g" "${CONFIG}"
 
-ingress_entry=$(bashio::addon.ingress_entry)
+ingress_entry=$(bashio::app.ingress_entry)
 sed -i "s#%%ingress_entry%%#${ingress_entry}#g" "${CONFIG}"
 
 # Install user configured/requested Grafana plugins

--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-nginx/run
@@ -11,7 +11,7 @@ declare ingress_entry
 declare keyfile
 
 
-port=$(bashio::addon.port 80)
+port=$(bashio::app.port 80)
 if bashio::var.has_value "${port}"; then
     bashio::config.require.ssl
 
@@ -26,7 +26,7 @@ if bashio::var.has_value "${port}"; then
     else
         mv /etc/nginx/servers/direct.disabled /etc/nginx/servers/direct.conf
     fi
-    ingress_entry=$(bashio::addon.ingress_entry)
+    ingress_entry=$(bashio::app.ingress_entry)
     sed -i "s#%%ingress_entry%%#${ingress_entry}#g" /etc/nginx/servers/direct.conf
 fi
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Bashio v0.18.0 renamed the `addon` namespace to `app` (hassio-addons/bashio#260), and the base image has shipped that since `debian-base` v9.4.0. This repository still called the old names.

Nothing was broken. Bashio generates a deprecated `bashio::addon.*` alias for every `bashio::app.*` function, so the calls kept working. The visible symptom was a warning in the app log the first time each alias was used, once per name per process:

```
WARNING: bashio::addon.port is deprecated, use bashio::app.port instead.
WARNING: bashio::addon.ingress_entry is deprecated, use bashio::app.ingress_entry instead.
```

This renames the three call sites to the current names:

| File | Was | Now |
| --- | --- | --- |
| `init-nginx/run` | `bashio::addon.port` | `bashio::app.port` |
| `init-nginx/run` | `bashio::addon.ingress_entry` | `bashio::app.ingress_entry` |
| `init-grafana/run` | `bashio::addon.ingress_entry` | `bashio::app.ingress_entry` |

Both replacements were confirmed to resolve inside `ghcr.io/hassio-addons/debian-base:9.4.0`.

### Everything else was already compatible

The other bashio functions used here were checked against the v0.19.0 source and are all still defined under their current names, none of them deprecated: `bashio::config`, `config.has_value`, `config.true`, `config.exists`, `config.require.ssl`, `log.info`, `log.warning`, `log.debug`, `net.wait_for`, `exit.nok`, `var.has_value`, `string.lower`, `fs.file_exists`.

The one breaking change in v0.18.0, making `bashio::string.replace` replace the needle literally (hassio-addons/bashio#220), does not apply: that function is not used in this repository.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Upstream: hassio-addons/bashio#260

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
