### PR TITLE
Remove image rendering support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,15 +36,6 @@
       ],
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "grafana/grafana"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": ["/Dockerfile$"],
-      "matchStrings": [
-        "ARG GRAFANA_IMAGE_RENDERER_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
-      ],
-      "datasourceTemplate": "github-releases",
-      "depNameTemplate": "grafana/grafana-image-renderer"
     }
   ],
   "packageRules": [

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -154,11 +154,26 @@ Assistant Cloud. This includes embedding Grafana resources with an iframe or
 rendered image inside of a dashboard. For more details see
 [Anonymous login not working, Grafana app 3.0.0 #55](https://github.com/hassio-addons/app-grafana/issues/55).
 
-## Known issues and limitations
+## Image rendering
 
-- `To render a panel image, you must install the Grafana Image Renderer plugin.`
-  This message is shown on ARM devices, like a Raspberry Pi. The Grafana Image
-  Renderer plugin is not available for these devices.
+This app does not include image rendering. Grafana used to offer this as the
+Grafana Image Renderer plugin, which was deprecated in September 2025 and, as
+of Grafana 13, is no longer loaded at all.
+
+Rendering is now provided by a separate service that you run alongside Grafana.
+If you need rendered panel or dashboard images, run that service and point this
+app at it using the `env_vars` option:
+
+```yaml
+env_vars:
+  - name: GF_RENDERING_SERVER_URL
+    value: http://your-renderer-host:8081/render
+  - name: GF_RENDERING_CALLBACK_URL
+    value: http://homeassistant.local:3000/
+```
+
+See the Grafana documentation on [image rendering][image-rendering] for how to
+deploy and configure the service.
 
 ## Changelog & Releases
 
@@ -227,6 +242,7 @@ SOFTWARE.
 [discord]: https://discord.me/hassioaddons
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-grafana/54674?u=frenck
 [frenck]: https://github.com/frenck
+[image-rendering]: https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/
 [influxdb-addon]: https://github.com/hassio-addons/addon-influxdb
 [issue]: https://github.com/hassio-addons/app-grafana/issues
 [reddit]: https://reddit.com/r/homeassistant

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -8,7 +8,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # Setup base system
 ARG BUILD_ARCH=amd64
 ARG GRAFANA_VERSION="v13.2.0"
-ARG GRAFANA_IMAGE_RENDERER_VERSION="v4.1.5"
 RUN \
     ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then ARCH="arm64"; fi \
@@ -18,37 +17,10 @@ RUN \
     \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        fonts-noto-cjk=1:20240730+repack1-1 \
         libfontconfig1=2.15.0-2.3 \
         memcached=1.6.38-1 \
         musl=1.2.5-3.1~deb13u1 \
         nginx=1.26.3-3+deb13u7 \
-    \
-    && if [ "${BUILD_ARCH}" = "amd64" ]; then \
-        apt-get install -y --no-install-recommends \
-            libasound2t64=1.2.14-1 \
-            libcups2t64=2.4.10-3+deb13u2 \
-            libdbus-1-3=1.16.2-2 \
-            libdrm-amdgpu1=2.4.124-2 \
-            libgbm1=25.0.7-2+deb13u1 \
-            libglib2.0-0t64=2.84.4-3~deb13u3 \
-            libgtk-4-1=4.18.6+ds-2 \
-            libnss3=2:3.110-1+deb13u4 \
-            libx11-6=2:1.8.12-1 \
-            libx11-xcb1=2:1.8.12-1 \
-            libxcb-dri3-0=1.17.0-2+b1 \
-            libxcomposite1=1:0.4.6-1 \
-            libxcursor1=1:1.2.3-1 \
-            libxdamage1=1:1.1.6-1+b2 \
-            libxext6=2:1.3.4-1+b3 \
-            libxfixes3=1:6.0.0-2+b4 \
-            libxi6=2:1.8.2-1 \
-            libxrandr2=2:1.5.4-1+b3 \
-            libxrender1=1:0.9.12-1 \
-            libxshmfence1=1.3.3-1 \
-            libxss1=1:1.2.3-1+b3 \
-            libxtst6=2:1.2.5-1; \
-    fi \
     \
     # Grafana 13 declares "Depends: systemd", which this s6 based image does not
     # provide. Its maintainer scripts only call systemctl on an upgrade, guarded
@@ -56,11 +28,6 @@ RUN \
     # run after every apt-get call: the unsatisfied dependency it leaves behind
     # makes apt refuse to resolve anything afterwards.
     && dpkg --install --force-depends /tmp/grafana.deb \
-    \
-    && if [ "${BUILD_ARCH}" = "amd64" ]; then \
-        grafana-cli --homepath /usr/share/grafana plugins install \
-            "grafana-image-renderer" "${GRAFANA_IMAGE_RENDERER_VERSION#v}"; \
-    fi \
     \
     && rm -fr \
         /tmp/* \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Removes image rendering, which no longer functions.

Grafana deprecated the Image Renderer plugin in September 2025, and **Grafana 13 removed plugin support entirely**. From the Grafana release note: "support for the plugin is fully removed and it no longer works for rendering screenshots or scheduled reports". Rendering now exists only as a service you deploy separately alongside Grafana.

Since #502 merged, this app has been downloading and shipping a renderer that Grafana silently ignores.

## Verified, not just assumed

Using the image built from `main`:

- The plugin is present: `/var/lib/grafana/plugins/grafana-image-renderer`, version `4.1.5`.
- Grafana 13 reports `Plugins loaded count=38`, **identical** whether or not the plugins path includes that directory.
- No renderer plugin is ever loaded. `rendering.RenderingService` still starts, but that is the built-in client for a remote renderer; it never picks up the plugin.

The Grafana.com plugin catalog also confirms the line ended: it lists 81 versions of `grafana-image-renderer`, the newest being `4.1.5`. There is no 5.x plugin, which is why #482 could never build.

## What is removed

| Item | Reason |
| --- | --- |
| `ARG GRAFANA_IMAGE_RENDERER_VERSION` and the plugin install | The plugin is not loaded by Grafana 13 |
| The entire `amd64` only block of 22 X and GTK pins | Present only for the renderer's bundled Chromium |
| `fonts-noto-cjk` | Added specifically for the renderer in #202 |
| The Renovate manager tracking `grafana/grafana-image-renderer` | Nothing left to track, and it tracked GitHub releases rather than the plugin catalog, which is why it kept proposing impossible v5 bumps |

`libfontconfig1` is kept: it predates the renderer, having been there since the initial add-on code.

## Result

The image drops from **2.45GB to 1.53GB**, a saving of **920MB**, around 38%. Verified locally: the build succeeds, Grafana reports `13.2.0` with `Status: install ok installed`, and nginx and memcached are unaffected.

`DOCS.md` replaces the old "Known issues and limitations" note, which described the renderer being unavailable on ARM, with an "Image rendering" section explaining that rendering now requires the separate service, including the `GF_RENDERING_SERVER_URL` and `GF_RENDERING_CALLBACK_URL` settings needed to point this app at one.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Closes #482, which bumped the renderer to v5. That version exists only as the standalone Go service and has no plugin artifact, so it could never be installed here.

Upstream: [Grafana Image Renderer plugin support removed](https://grafana.com/whats-new/2026-04-14-grafana-image-renderer-plugin-support-removed/), [image rendering documentation](https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring image rendering through a separate service.
  * Documented the relevant rendering URL settings and linked to Grafana’s official documentation.
  * Removed outdated information about the image renderer plugin.

* **Changes**
  * Removed the bundled image renderer plugin and related dependencies from the Grafana image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->