### PR TITLE
Drop the unused musl package pin

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -19,7 +19,6 @@ RUN \
     && apt-get install -y --no-install-recommends \
         libfontconfig1=2.15.0-2.3 \
         memcached=1.6.38-1 \
-        musl=1.2.5-3.1~deb13u1 \
         nginx=1.26.3-3+deb13u7 \
     \
     # Grafana 13 declares "Depends: systemd", which this s6 based image does not


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Drops the `musl` apt pin, which nothing in the image needs any more.

It was there because the Grafana `.deb` used to require it. Grafana 12.3.1 declared `Depends: adduser, musl`; Grafana 13.2.0 declares `Depends: adduser, systemd`, on both `amd64` and `arm64`. The other plausible consumer, the image renderer's bundled Chromium, was removed in #521.

## Verification

Built without the pin, then scanned the resulting image:

- **464 ELF binaries scanned: 0 musl-linked, 0 with missing libraries.** Every executable in the image was checked for both a `ld-musl-*` program interpreter and unresolved `ldd` entries.
- No musl loader is present on disk, and the package is absent from the dpkg database.
- Grafana starts and reaches `HTTP Server Listen address=[::]:3000`.
- `nginx` and `memcached` both run.
- `grafana-cli --homepath ... plugins install` still works, which is the runtime path used by the `plugins` and `custom_plugins` options.

Grafana logs two `plugin prometheus not found` errors on startup under this test, but those are an artifact of running against `defaults.ini` rather than the app's real config. The error set is byte for byte identical to the image built from `main` with `musl` still installed, so the removal changes nothing at runtime.

The image size is unchanged at 1.53GB; `musl` is small, so this is about not shipping and tracking a package we do not use rather than about size.

Hadolint, shellcheck, prettier and yamllint are all clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow up on #502, which moved to Grafana 13 and dropped the dependency, and #521, which removed the image renderer.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Grafana container setup by removing an explicit system package installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->