### PR TITLE
Use the non-deprecated grafana server and grafana cli subcommands

### DIFF
--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/grafana/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/grafana/run
@@ -37,4 +37,4 @@ if bashio::config.has_value 'custom_plugins'; then
 fi
 
 # Run Grafana
-exec grafana-server "${options[@]}"
+exec grafana server "${options[@]}"

--- a/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
+++ b/grafana/rootfs/etc/s6-overlay/s6-rc.d/init-grafana/run
@@ -54,7 +54,7 @@ sed -i "s#%%ingress_entry%%#${ingress_entry}#g" "${CONFIG}"
 # Install user configured/requested Grafana plugins
 if bashio::config.has_value 'plugins'; then
     for plugin in $(bashio::config 'plugins'); do
-        grafana-cli --homepath "${HOMEPATH}" plugins install "$plugin" \
+        grafana cli --homepath "${HOMEPATH}" plugins install "$plugin" \
             || bashio::exit.nok "Failed installing Grafana plugin: ${plugin}"
     done
 fi
@@ -65,7 +65,7 @@ if bashio::config.has_value 'custom_plugins'; then
         name=$(bashio::config "custom_plugins[${plugin}].name")
         url=$(bashio::config "custom_plugins[${plugin}].url")
         bashio::log.debug "Installing custom plugin ${name} from ${url}"
-        grafana-cli --homepath "${HOMEPATH}" --pluginUrl "${url}" \
+        grafana cli --homepath "${HOMEPATH}" --pluginUrl "${url}" \
             plugins install "${name}" \
             || bashio::exit.nok "Failed installing Grafana custom plugin: ${name} from: ${url}"
     done


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Moves off `grafana-server` and `grafana-cli`, both deprecated in Grafana 13:

```
Deprecation warning: 'grafana-server' is deprecated and will be removed in a future release. Use the 'grafana server' subcommand instead.
Deprecation warning: 'grafana-cli' is deprecated and will be removed in a future release. Use the 'grafana cli' subcommand instead.
```

Three call sites: the main process in `grafana/run`, and both plugin installs in `init-grafana/run`. The second and third matter beyond the warning, since they run at start-up for anyone using the `plugins` or `custom_plugins` options.

## Why this is safe

Both deprecated commands are thin wrapper scripts. `/usr/sbin/grafana-server` is eleven lines that print the warning and then:

```bash
exec "$EXECUTABLE" server "$@"
```

`/usr/sbin/grafana-cli` is the same with `cli`. So the deprecated form already routed to the subcommand this PR now calls directly.

## One behaviour change, verified

`grafana server` and `grafana cli` go through `/usr/sbin/grafana`, which prepends package paths via `--configOverrides` that the deprecated wrappers did not set. Comparing the resolved paths at start-up:

| Path | `grafana-server` | `grafana server` |
| --- | --- | --- |
| Data | `/data` | `/data` |
| Home | `/usr/share/grafana` | `/usr/share/grafana` |
| Logs | `/var/logs/grafana` | `/var/logs/grafana` |
| Plugins | `/var/lib/grafana/plugins`, `plugins-bundled` | `/var/lib/grafana/plugins`, `plugins-bundled` |
| Provisioning | `/usr/share/grafana/conf/provisioning` | `/etc/grafana/provisioning` |

**Data stays on `/data`.** That was the risk worth checking: the wrapper's override sets `default.paths.data=/var/lib/grafana`, but our `grafana.ini` `[paths] data = /data` takes precedence, so the persistent volume is untouched and no dashboards move.

**Provisioning changes location.** This is inert in practice: neither directory defines an active provisioning provider. The old path carries extra sample dashboard JSON, but nothing references it, and the new path is the location the Debian package's `postinst` actually creates and manages. Users who want a different directory can still set `GF_PATHS_PROVISIONING` through `env_vars`.

If you would rather have zero delta, adding `provisioning = /usr/share/grafana/conf/provisioning` to `[paths]` in `grafana.ini` pins the old location.

## Verification

- `grafana cli ... plugins install <id>` and `grafana cli ... --pluginUrl <url> plugins install <name>` both exit 0 and install to `/var/lib/grafana/plugins`, matching the deprecated form.
- `grafana server` starts and reaches `HTTP Server Listen address=[::]:3000` with the ingress `subUrl` applied correctly.
- End to end from the built image: plugin installed, server started, `Plugins loaded count=39`, which is the 38 bundled plugins plus the one installed through the new CLI form.
- No deprecation warnings remain in the output.
- Error output is identical between the two forms across repeated runs. An earlier single run showed two extra plugin errors under the old form; re-running each form twice more produced none, so that was a shutdown race rather than a real difference.

Build succeeds, and shellcheck and hadolint are clean.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow up on #502, which moved to Grafana 13 and introduced these deprecations.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Grafana startup and plugin installation commands to use the current Grafana command-line interface.
  * Preserved existing startup options, plugin installation behavior, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->