### PR TITLE
Drop the InfluxDB add-on links from the documentation

### DIFF
--- a/grafana/.README.j2
+++ b/grafana/.README.j2
@@ -61,8 +61,6 @@ If you are more interested in stable releases of our apps:
 <https://github.com/hassio-addons/repository>
 
 {% endif %}
-[discord]: https://discord.me/hassioaddons
-[forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-grafana/54674?u=frenck
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg

--- a/grafana/DOCS.md
+++ b/grafana/DOCS.md
@@ -110,12 +110,11 @@ documentation:
 
 **Note**: _Only environment variables starting with `GF_` are accepted._
 
-## Using it with the InfluxDB Community app
+## Using it with InfluxDB
 
 Grafana does not come out of the box pre-configured, but letting it interact
-with the community [InfluxDB app][influxdb-addon] is pretty easy. Please
-follow their instructions on how to [create a database][create-db] for Home
-Assistant.
+with InfluxDB is pretty easy. Make sure you have an InfluxDB database for Home
+Assistant set up first, then:
 
 1. Create a new user for Grafana on InfluxDB
    (InfluxDB Admin -> Users and "+ Create User")
@@ -238,13 +237,11 @@ SOFTWARE.
 [addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_grafana&repository_url=https%3A%2F%2Fgithub.com%2Fhassio-addons%2Frepository
 [contributors]: https://github.com/hassio-addons/app-grafana/graphs/contributors
-[create-db]: https://github.com/hassio-addons/addon-influxdb/blob/main/influxdb/DOCS.md#integrating-into-home-assistant
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-grafana/54674?u=frenck
 [frenck]: https://github.com/frenck
 [image-rendering]: https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/
-[influxdb-addon]: https://github.com/hassio-addons/addon-influxdb
 [issue]: https://github.com/hassio-addons/app-grafana/issues
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/app-grafana/releases


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Removes the two links to `hassio-addons/addon-influxdb`, since that add-on is being retired.

The "Using it with the InfluxDB Community app" section is now "Using it with InfluxDB". The steps themselves are unchanged and still apply to any InfluxDB instance; only the framing and the two links are gone. The sentence that pointed at the InfluxDB add-on's own docs for creating a database now simply states that a database needs to exist first.

Both link definitions are removed:

- `[create-db]`, which pointed at that repository's `DOCS.md`
- `[influxdb-addon]`, which pointed at the repository itself

## Also removed: two orphaned link definitions

While checking that nothing was left dangling, `.README.j2` turned out to still define `[discord]` and `[forum]` even though nothing references them. They were orphaned by #518, which removed the chat and community forum badges from the template. Unlike `README.md`, the template has no Support section, so nothing used them afterwards.

Every markdown reference across `DOCS.md`, `README.md` and `.README.j2` now resolves, with no unused definitions left in any of the three.

## One thing left alone

The datasource example still uses `http://a0d7b954-influxdb:8086`, which is the InfluxDB add-on's container hostname. It is not a link, so it is outside what this PR was asked to change, and it remains correct for anyone still running that add-on today. Worth generalising once the add-on is actually gone.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow up on #518, which orphaned the template link definitions, and #522, which covered the rest of the documentation sweep.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
